### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ elixir_version=(tag v0.12.5)
 elixir_version=(commit b07fbcf8b73e)
 ```
 
-#### Specifying Erlang verisons
+#### Specifying Erlang version
 
 * You can either specify a stable Erlang release version like below
 


### PR DESCRIPTION
A Google search gives me "About 130,000 results".
I was starting to think that the word "verisons" really existed :confused:
