### PR TITLE
add a configuration option to export env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * Use **prebuilt Elixir binaries** or build from source
 * Mix **dependency caching**
 * Adds the free Heroku Postgres **database upon app creation**
-* `DATABASE_URL` is made available at compile time
+* `DATABASE_URL` can be made available at compile time adding it to `config_vars_to_export` in `elixir_buildpack.config`
 * Allows configuring Erlang
 * If your app doesn't have a Procfile, default web task `mix server -p $PORT` will be run.
 * Consolidates protocols
@@ -51,6 +51,9 @@ elixir_version=0.12.5
 
 # Do dependencies have to be built from scratch on every deploy?
 always_build_deps=false
+
+# Export heroku config vars
+config_vars_to_export=(DATABASE_URL)
 ```
 
 
@@ -90,6 +93,19 @@ erlang_version=(branch master)
 
 Note that if you specify the master branch of Erlang, then it is Heroku's periodic builds that will be used. I don't work for Heroku, but I'm assuming that's why they have master branch builds.
 
+#### Specifying config vars to export at compile time
+
+* To set a config var on your heroku node you can exec from the shell:
+
+```
+heroku config:set MY_VAR=the_value
+```
+
+* Add the config vars you want to be exported in your `elixir_buildpack.config` file:
+
+```
+config_vars_to_export=(DATABASE_URL MY_VAR)
+```
 
 ## Other notes
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ mkdir $(platform_tools_path)
 
 commands_to_run=(
   load_config
-  export_database_url
+  export_config_vars
 
   download_erlang
   install_erlang

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,3 +1,4 @@
 erlang_version=17.0
 elixir_version=0.13.2
 always_build_deps=false
+config_vars_to_export=(DATABASE_URL)

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -70,13 +70,17 @@ function load_config() {
   output_line "Will use the following versions:"
   output_line "* Erlang ${erlang_version}"
   output_line "* Elixir ${elixir_version[0]} ${elixir_version[1]}"
+  output_line "Will export the following config vars:"
+  output_line "* Config vars ${config_vars_to_export}"
 }
 
 
-# Make the DATABASE_URL available at slug compile time.
+# Make the config vars from config_vars_to_export available at slug compile time.
 # Useful for compiled languages like Erlang and Elixir
-function export_database_url() {
-  if [ -d $env_path ] && [ -f $env_path/DATABASE_URL ]; then
-    export DATABASE_URL=$(cat $env_path/DATABASE_URL)
-  fi
+function export_config_vars() {
+  for config_var in ${config_vars_to_export[@]}; do
+    if [ -d $env_path ] && [ -f $env_path/${config_var} ]; then
+      export ${config_var}=$(cat $env_path/${config_var})
+    fi
+  done
 }


### PR DESCRIPTION
Add a way to make [Heroku config vars](https://devcenter.heroku.com/articles/config-vars) available at slug compile time.

`elixir_buildpack.config` example:

``` bash
# Erlang version
erlang_version=17.0

# Elixir version
elixir_version=(tag v0.14.1)

# Do dependencies have to be built from scratch on every deploy?
always_build_deps=false

# Export heroku config vars
config_vars_to_export=(DATABASE_URL SESSION_SECRET)
```

This remove `export_database_url` and add `export_config_vars`.

Should we keep `export_database_url` for backwards compatibility?
