### PR TITLE
fix `cache_path: command not found` error

### DIFF
--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -89,6 +89,6 @@ function export_config_vars() {
 function clean_cache() {
   if [ $always_rebuild = true ]; then
     output_line "Cleaning all cache to force rebuilds"
-    rm -rf $(cache_path)
+    rm -rf $cache_path/*
   fi
 }


### PR DESCRIPTION
The following error occurred when `always_rebuild` is true.

```
       Cleaning all cache to force rebuilds
/tmp/buildpack_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/lib/misc_funcs.sh:
line 92: cache_path: command not found
```

And do not remove cache directory.
