### PR TITLE
Fix #18: Use unzip on Cedar-14 stack, else fallback to jar

### DIFF
--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -21,7 +21,14 @@ function install_elixir() {
 
   mkdir -p $(elixir_path)
   cd $(elixir_path)
-  jar xf ${cache_path}/$(elixir_download_file)
+
+  # Cedar-14 has unzip. Older Heroku stacks don't have it
+  if hash unzip 2>/dev/null; then
+    unzip ${cache_path}/$(elixir_download_file)
+  else
+    jar xf ${cache_path}/$(elixir_download_file)
+  fi
+
   cd - > /dev/null
 
   chmod +x $(elixir_path)/bin/*


### PR DESCRIPTION
The new cedar-14 stack now has `unzip`. We were depending on `jar` to unzip files, which is not available on the newer stack.

This fix supports both older `cedar` stack and the newer `cedar-14` stack (which is the default Heroku stack for new apps).

Fixes #18
