### PR TITLE
Hex archive can have a different name from hex.ez for custom or interim builds

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -20,7 +20,7 @@ function copy_hex() {
   mkdir -p ${build_path}/.hex
 
   cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
-  cp ${HOME}/.mix/archives/hex.ez ${build_path}/.mix/archives
+  cp ${HOME}/.mix/archives/`basename ${hex_source}` ${build_path}/.mix/archives
 }
 
 


### PR DESCRIPTION
I had this issue with https://s3.hex.pm.s3.amazonaws.com/installs/hex-0.6.3-dev.ez