### PR TITLE
Hex archive can have a different name from hex.ez for custom or interim builds

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -19,8 +19,10 @@ function copy_hex() {
   mkdir -p ${build_path}/.mix/archives
   mkdir -p ${build_path}/.hex
 
+  hex_file=`basename ${hex_source:-hex.ez}`
+
   cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
-  cp ${HOME}/.mix/archives/hex.ez ${build_path}/.mix/archives
+  cp ${HOME}/.mix/archives/${hex_file} ${build_path}/.mix/archives
 }
 
 


### PR DESCRIPTION
Sorry about the previous mixup. This one should handle undefined `hex_source`