### PR TITLE
Add support for exrm releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 * Consolidates protocols
 * Hex and rebar support
 * Caching of Hex packages, Mix dependencies and downloads
+* exrm releases support
 
 
 #### Version support info
@@ -54,6 +55,9 @@ always_rebuild=false
 
 # Export heroku config vars
 config_vars_to_export=(DATABASE_URL)
+
+# Support exrm releases
+exrm_release=false
 ```
 
 
@@ -92,6 +96,10 @@ heroku config:set MY_VAR=the_value
 ```
 config_vars_to_export=(DATABASE_URL MY_VAR)
 ```
+
+## exrm release
+
+if exrm support is enabled then after compilation, the task 'mix release' is also run.
 
 ## Other notes
 

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,5 @@
 erlang_version=17.3.4
 elixir_version=1.0.2
 always_rebuild=false
+exrm_release=false
 config_vars_to_export=(DATABASE_URL)

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -69,6 +69,11 @@ function compile_app() {
   mix compile --force || exit 1
   mix compile.protocols || exit 1
 
+  # if exrm release are activated then run the release task
+  if [ $exrm_release = true ]; then
+    mix release
+  fi
+
   export GIT_DIR=$git_dir_value
   cd - > /dev/null
 }

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -71,6 +71,7 @@ function compile_app() {
 
   # if exrm release are activated then run the release task
   if [ $exrm_release = true ]; then
+    output_section "Releasing the app"
     mix release
   fi
 


### PR DESCRIPTION
I added a configuration option which allow to enable/disable exrm releases. When enabled, the task 'mix release' is executed after the compilation