### PR TITLE
mkdir -p .profile.d

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -70,7 +70,7 @@ function compile_app() {
 
 function write_profile_d_script() {
   output_section "Creating .profile.d with env vars"
-  mkdir $build_path/.profile.d
+  mkdir -p $build_path/.profile.d
 
   local export_line="export PATH=\$HOME/.platform_tools:\$HOME/.platform_tools/erlang/bin:\$HOME/.platform_tools/elixir/bin:\$PATH
                      export LC_CTYPE=en_US.utf8


### PR DESCRIPTION
My initial build on a [dokku](https://github.com/progrium/dokku) instance failed at creating the .profile.d dir as it already existed. This fixes that.

Thanks for the buildpack :+1: 