### PR TITLE
Print all elements of config_vars_to_export

### DIFF
--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -72,7 +72,7 @@ function load_config() {
   output_line "* Erlang ${erlang_version}"
   output_line "* Elixir ${elixir_version[0]} ${elixir_version[1]}"
   output_line "Will export the following config vars:"
-  output_line "* Config vars ${config_vars_to_export}"
+  output_line "* Config vars ${config_vars_to_export[*]}"
 }
 
 


### PR DESCRIPTION
If you specify multiple config_vars_to_export, only the first is printed as being exported because [Bash is dumb](http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_10_02.html#sect_10_02_02):

> Referring to the content of a member variable of an array without providing an index number is the same as referring to the content of the first element, the one referenced with index number zero.

It still actually exports them all, the "* Config vars" line would just only include the first variable.

This fixes it and prints them all.