### PR TITLE
Use post_compile option from buildpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ always_rebuild=false
 
 # Export heroku config vars
 config_vars_to_export=(DATABASE_URL)
+
+# A command to run right before starting the app
+post_compile="pwd"
 ```
 
 

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -63,9 +63,9 @@ function compile_app() {
 function post_compile_hook() {
   cd $build_path
 
-  if [ -f post_compile.sh ]; then
-    output_section "Executing post_compile.sh"
-    ./post_compile.sh || exit 1
+  if [ -n "$post_compile" ]; then
+    output_section "Executing post compile: $post_compile"
+    $post_compile || exit 1
   fi
 
   cd - > /dev/null


### PR DESCRIPTION
Changes from using `post_compile.sh` to reading the `post_compile` option from the buildpack config.