### PR TITLE
Include $PORT in config_vars_to_export

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
 erlang_version=17.5
 elixir_version=1.0.4
 always_rebuild=false
-config_vars_to_export=(DATABASE_URL)
+config_vars_to_export=(PORT DATABASE_URL)


### PR DESCRIPTION
Just following along [Phoenix's guides for an Heroku deployment](http://www.phoenixframework.org/docs/heroku#section-making-our-project-heroku-ready) and noticed the absense of passing [Heroku's $PORT](https://devcenter.heroku.com/articles/procfile) through as a default config var?

What's your thoughts on this added default config var?