### PR TITLE
Check for hex archive file names in order

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -14,17 +14,24 @@ function restore_app() {
 function copy_hex() {
   mkdir -p ${build_path}/.mix/archives
   mkdir -p ${build_path}/.hex
-  hex_file=`basename ${hex_source:-hex-*.ez}`
 
-  # For older versions of hex which have no version name in file
-  if [ -z "$hex_file" ]; then
-    hex_file="hex.ez"
+  if [ -z "$hex_source" ]; then
+    hex_file=`basename ${hex_source}`
+  else
+    # hex file names after elixir-1.1 in the hex-<version>.ez form
+    hex_file=$(ls -t ${HOME}/.mix/archives/hex-*.ez | head -n 1)
+
+    # For older versions of hex which have no version name in file
+    if [ -z "$hex_file" ]; then
+      hex_file="hex.ez"
+    fi
   fi
 
   cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
-  
-  output_section "Copying hex from $hex_file"
-  cp ${HOME}/.mix/archives/${hex_file} ${build_path}/.mix/archives
+
+  full_hex_file_path=${HOME}/.mix/archives/${hex_file}
+  output_section "Copying hex from $full_hex_file_path"
+  cp $full_hex_file_path ${build_path}/.mix/archives
 }
 
 


### PR DESCRIPTION
This PR removes the need for a wildcard as per Eric's tip off about other libs having files hex* mix archive files.

* First check for file name in $hex_source if specified
* Then check for first hex file in the new hex-<version>.ez format
* Fall back to old hex.ez file (very unlikely to hit this condition)

\\cc: @ericmj 

P.S: @chrismcg can you try the `HashNuke-hex-path-patch` branch to deploy?