### PR TITLE
Support custom package urls

### DIFF
--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -8,7 +8,8 @@ function download_elixir() {
 
     output_section "Fetching Elixir ${elixir_version}"
 
-    local download_url="https://s3.amazonaws.com/s3.hex.pm/builds/elixir/${elixir_version}.zip"
+    local elixir_package_url=${ELIXIR_PACKAGE_URL:-"https://s3.amazonaws.com/s3.hex.pm/builds/elixir"}
+    local download_url="${elixir_package_url}/${elixir_version}.zip"
     curl -s ${download_url} -o ${cache_path}/$(elixir_download_file) || exit 1
   else
     output_section "Using cached Elixir ${elixir_version}"

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -3,7 +3,7 @@ function erlang_tarball() {
 }
 
 function download_erlang() {
-  erlang_package_url="https://s3.amazonaws.com/s3.hex.pm/builds/erlang/cedar-14"
+  erlang_package_url=${ERLANG_PACKAGE_URL:-"https://s3.amazonaws.com/s3.hex.pm/builds/erlang/cedar-14"}
   erlang_package_url="${erlang_package_url}/$(erlang_tarball)"
 
   # If a previous download does not exist, then always re-download


### PR DESCRIPTION
So that one can run the latest version of erlang/elixir without having to wait for the compiled packages to be published.