### PR TITLE
Don't hard-code runtime application path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ config_vars_to_export=(DATABASE_URL)
 
 # A command to run right after compiling the app
 post_compile="pwd"
+
+# Set the path the app is run from
+runtime_path=/app
 ```
 
 

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -2,3 +2,4 @@ erlang_version=18.1.3
 elixir_version=1.2.0
 always_rebuild=false
 config_vars_to_export=(DATABASE_URL)
+runtime_path=/app

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -31,10 +31,10 @@ function install_erlang() {
   mkdir -p $(erlang_build_path)
   tar zxf ${cache_path}/$(erlang_tarball) -C $(erlang_build_path) --strip-components=1
 
-  rm -rf /app/.platform_tools/erlang
-  mkdir -p /app/.platform_tools
-  ln -s $(erlang_build_path) /app/.platform_tools/erlang
-  $(erlang_build_path)/Install -minimal /app/.platform_tools/erlang
+  rm -rf $(runtime_erlang_path)
+  mkdir -p $(runtime_platform_tools_path)
+  ln -s $(erlang_build_path) $(runtime_erlang_path)
+  $(erlang_build_path)/Install -minimal $(runtime_erlang_path)
 
   cp -R $(erlang_build_path) $(erlang_path)
   PATH=$(erlang_path)/bin:$PATH

--- a/lib/path_funcs.sh
+++ b/lib/path_funcs.sh
@@ -6,6 +6,14 @@ function erlang_path() {
   echo "$(platform_tools_path)/erlang"
 }
 
+function runtime_platform_tools_path() {
+  echo "${runtime_path}/.platform_tools"
+}
+
+function runtime_erlang_path() {
+  echo "$(runtime_platform_tools_path)/erlang"
+}
+
 function elixir_path() {
   echo "$(platform_tools_path)/elixir"
 }


### PR DESCRIPTION
It is not guaranteed that the app is installed to /app. Users of buildpacks other than Heroku require applications to be stored at other paths, such as [pkgr](http://github.com/crohr/pkgr) which uses /opt/${APP_NAME}. Furthermore, the source may not be located at /app at compile time, since not every buildpack executor uses a layered filesystem, and so must resort to using a sandbox build directory (some call this the good old days).

This seems to have been broken by f651aacae97df3f28cd86cadef96dcf850e7d0d8.

See https://github.com/crohr/pkgr/issues/93 for the source of this.