### PR TITLE
[Urgent] Update Elixir to 1.2.3

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
 erlang_version=18.2.1
-elixir_version=1.2.2
+elixir_version=1.2.3
 always_rebuild=false
 config_vars_to_export=(DATABASE_URL)


### PR DESCRIPTION
Elixir 1.2.2 contains a serious build/compile bug that causes random errors, due to some outdated binaries aren't rebuilt. This bug is resolved in version 1.2.3.

We must move the default away from this version 1.2.2, least unsuspecting users using default settings encounter random errors.