### PR TITLE
Add rebar to PATH after installation

### DIFF
--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -95,6 +95,8 @@ function install_rebar() {
   output_section "Installing rebar"
 
   mix local.rebar --force
+
+  PATH=${PATH}:${HOME}/.mix
 }
 
 function elixir_changed() {


### PR DESCRIPTION
The `ssl_verify_hostname` package failed to compile when I pushed to Heroku. Turns out `rebar` wasn't available on the `PATH`. This fixes that.