### PR TITLE
Recommend use of buildpacks:set instead of of older BUILDPACK_URL config var

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@
 heroku create --buildpack "https://github.com/HashNuke/heroku-buildpack-elixir.git"
 ```
 
-#### Set the buildpack of an existing Heroku app
+#### Set the buildpack for an existing Heroku app
 
 ```
-heroku config:set BUILDPACK_URL="https://github.com/HashNuke/heroku-buildpack-elixir.git"
+heroku buildpacks:set https://github.com/HashNuke/heroku-buildpack-elixir
 ```
 
 The above method always uses the latest version of the buildpack. To use a specific older version of the buildpack, [see notes below](#using-older-version-of-buildpack).


### PR DESCRIPTION
`heroku buildpacks:set` is preferred over the older `BUILDPACK_URL` config var.  This change will also make the instructions match up with our [buildpack documentation](https://devcenter.heroku.com/articles/buildpacks).