### PR TITLE
Hex installation fix for Elixir 1.3.0

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -21,7 +21,7 @@ function copy_hex() {
     full_hex_file_path=${HOME}/.mix/archives/${hex_file}
   else
     # hex file names after elixir-1.1 in the hex-<version>.ez form
-    full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-*.ez | head -n 1)
+    full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-* | head -n 1)
 
     # For older versions of hex which have no version name in file
     if [ -z "$full_hex_file_path" ]; then
@@ -32,7 +32,7 @@ function copy_hex() {
   cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
 
   output_section "Copying hex from $full_hex_file_path"
-  cp $full_hex_file_path ${build_path}/.mix/archives
+  cp -R $full_hex_file_path ${build_path}/.mix/archives
 }
 
 

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -15,23 +15,17 @@ function copy_hex() {
   mkdir -p ${build_path}/.mix/archives
   mkdir -p ${build_path}/.hex
 
-  if [ -n "$hex_source" ]; then
-    hex_file=`basename ${hex_source}`
+  # hex file names after elixir-1.1 in the hex-<version>.ez form
+  full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-* | head -n 1)
 
-    full_hex_file_path=${HOME}/.mix/archives/${hex_file}
-  else
-    # hex file names after elixir-1.1 in the hex-<version>.ez form
-    full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-* | head -n 1)
-
-    # For older versions of hex which have no version name in file
-    if [ -z "$full_hex_file_path" ]; then
-      full_hex_file_path=${HOME}/.mix/archives/hex.ez
-    fi
+  # For older versions of hex which have no version name in file
+  if [ -z "$full_hex_file_path" ]; then
+    full_hex_file_path=${HOME}/.mix/archives/hex.ez
   fi
 
   cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
 
-  output_section "Copying hex from $full_hex_file_path"
+  output_section "Copying hex from: $full_hex_file_path"
   cp -R $full_hex_file_path ${build_path}/.mix/archives
 }
 

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -15,8 +15,14 @@ function copy_hex() {
   mkdir -p ${build_path}/.mix/archives
   mkdir -p ${build_path}/.hex
 
+
+  # hex is a directory from elixir-1.3.0
+  full_hex_file_path=$(ls -dt ${HOME}/.mix/archives/hex-* | head -n 1)
+
   # hex file names after elixir-1.1 in the hex-<version>.ez form
-  full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-* | head -n 1)
+  if [ -z "$full_hex_file_path" ]; then
+    full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-*.ez | head -n 1)
+  fi
 
   # For older versions of hex which have no version name in file
   if [ -z "$full_hex_file_path" ]; then
@@ -25,7 +31,7 @@ function copy_hex() {
 
   cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
 
-  output_section "Copying hex from: $full_hex_file_path"
+  output_section "Copying hex from $full_hex_file_path"
   cp -R $full_hex_file_path ${build_path}/.mix/archives
 }
 


### PR DESCRIPTION
hex is a directory since `.mix/archives` since `1.3.0`

This fix enables working with both Elixir `1.2.x` line with .ez hex archive AND `1.3.0-rc.1`.