### PR TITLE
fix issue with correct export of PATH

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,5 @@
-erlang_version=18.2.1
-elixir_version=1.2.3
+erlang_version=18.3
+elixir_version=1.2.6
 always_rebuild=false
 config_vars_to_export=(DATABASE_URL)
 runtime_path=/app

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -100,7 +100,7 @@ function write_profile_d_script() {
   output_section "Creating .profile.d with env vars"
   mkdir -p $build_path/.profile.d
 
-  local export_line="export PATH=\$HOME/.platform_tools:\$HOME/.platform_tools/erlang/bin:\$HOME/.platform_tools/elixir/bin:\$PATH
+  local export_line="export PATH=\$HOME/.platform_tools:\$HOME/.platform_tools/erlang/bin:\$HOME/.platform_tools/elixir/bin:$PATH
                      export LC_CTYPE=en_US.utf8
                      export MIX_ENV=${MIX_ENV}"
 
@@ -110,7 +110,7 @@ function write_profile_d_script() {
 function write_export() {
   output_section "Writing export for multi-buildpack support"
 
-  local export_line="export PATH=$(platform_tools_path):$(erlang_path)/bin:$(elixir_path)/bin:\$PATH
+  local export_line="export PATH=$(platform_tools_path):$(erlang_path)/bin:$(elixir_path)/bin:$PATH
                      export LC_CTYPE=en_US.utf8
                      export MIX_ENV=${MIX_ENV}"
 

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -100,7 +100,7 @@ function write_profile_d_script() {
   output_section "Creating .profile.d with env vars"
   mkdir -p $build_path/.profile.d
 
-  local export_line="export PATH=\$HOME/.platform_tools:\$HOME/.platform_tools/erlang/bin:\$HOME/.platform_tools/elixir/bin:$PATH
+  local export_line="export PATH=\$HOME/.platform_tools:\$HOME/.platform_tools/erlang/bin:\$HOME/.platform_tools/elixir/bin:\$PATH
                      export LC_CTYPE=en_US.utf8
                      export MIX_ENV=${MIX_ENV}"
 


### PR DESCRIPTION
I am not entirely sure about the intention for escaping PATH in `profile.d/<script.sh>` or `export` but esp. for `/export`, it didn't work if `$PATH` is escaped because the `$PATH` in the context of the currently executing buildpack and the one in the context of `export` execution before the next buildpack (but its not clear in the [docs](https://devcenter.heroku.com/articles/buildpack-api#composing-multiple-buildpacks)) are different.

Based on my test (while I was playing with https://github.com/techgaun/heroku-buildpack-mix-tasks because we wanted to automate couple of custom mix tasks we use internally as part of heroku deployment), I saw that `$PATH` when escaped gets back to the default `$PATH`'s value (which typically is `/app/bin:/app/vendor/bundle/bin:/app/vendor/bundle/ruby/2.3.0/bin:/usr/local/bin:/usr/bin:/bin:/tmp/codon/vendor/bin`). I noticed this when the `node` path set by nodejs buildpack was no more available after this buildpack ran and we needed `node` in our mix tasks.

I did see it escaped on https://github.com/heroku/heroku-buildpack-nodejs/blob/master/lib/environment.sh#L45-L46 but probably it has never been noticed because it is usually the first one in buildpack sequence (at least for us :) ) and it does not matter in such case.
