### PR TITLE
check for already set MIX_ENV before defaulting

### DIFF
--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -57,10 +57,12 @@ function export_config_vars() {
 }
 
 function export_mix_env() {
-  if [ -d $env_path ] && [ -f $env_path/MIX_ENV ]; then
-    export MIX_ENV=$(cat $env_path/MIX_ENV)
-  else
-    export MIX_ENV=prod
+  if [ -z "$MIX_ENV" ]; then 
+    if [ -d $env_path ] && [ -f $env_path/MIX_ENV ]; then
+      export MIX_ENV=$(cat $env_path/MIX_ENV)
+    else
+      export MIX_ENV=prod
+    fi
   fi
 
   output_line "* MIX_ENV=${MIX_ENV}"


### PR DESCRIPTION
This is a fix for Cloud Foundry which does not pass the env_path during compile step, but env vars can be set before the buildpack runs, without this change we could set MIX_ENV=staging but still the buildpack would run as prod.

It simply checks MIX_ENV is not set before checking the env folder or defaulting to prod.

It does not have any effect if MIX_ENV is not set and would work as before