### PR TITLE
Follow Heroku convention to use camelcase for platform names

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -4,7 +4,7 @@ mix_file_url="$1/mix.exs"
 
 if [ -f $mix_file_url ];
 then
-  echo "elixir"
+  echo "Elixir"
   exit 0
 else
   exit 1


### PR DESCRIPTION
Following:
- https://github.com/heroku/heroku-buildpack-ruby/blob/master/bin/detect#L4
- https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/detect#L5