### PR TITLE
Feature(ENV_VAR): adding `export_default_env_vars`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ elixir_version=1.2.0
 # Always rebuild from scratch on every deploy?
 always_rebuild=false
 
-# Export heroku config vars
-config_vars_to_export=(DATABASE_URL)
-
 # A command to run right before compiling the app (after elixir, .etc)
 pre_compile="pwd"
 
@@ -71,6 +68,13 @@ post_compile="pwd"
 runtime_path=/app
 ```
 
+
+#### Migrating from previous build pack
+the following has been deprecated:
+```
+# Export heroku config vars
+config_vars_to_export=(DATABASE_URL)
+```
 
 #### Specifying Elixir version
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,6 @@ mkdir $(platform_tools_path)
 
 load_config
 export_default_env_vars
-export_config_vars
 export_mix_env
 
 check_stack

--- a/bin/compile
+++ b/bin/compile
@@ -25,6 +25,7 @@ source ${build_pack_path}/lib/app_funcs.sh
 mkdir $(platform_tools_path)
 
 load_config
+export_default_env_vars
 export_config_vars
 export_mix_env
 

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ source ${build_pack_path}/lib/app_funcs.sh
 mkdir $(platform_tools_path)
 
 load_config
-export_default_env_vars
+export_env_vars
 export_mix_env
 
 check_stack

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,4 @@
 erlang_version=18.3
 elixir_version=1.3.4
 always_rebuild=false
-config_vars_to_export=(DATABASE_URL)
 runtime_path=/app

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -58,9 +58,13 @@ function export_config_vars() {
 
 
 function export_default_env_vars() {
+  whitelist_regex=${2:-''}
+  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
   if [ -d "$ENV_DIR" ]; then
     for e in $(ls $ENV_DIR); do
+      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
       export "$e=$(cat $ENV_DIR/$e)"
+      :
     done
   fi
 }

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -56,6 +56,15 @@ function export_config_vars() {
   done
 }
 
+
+function export_default_env_vars() {
+  if [ -d "$ENV_DIR" ]; then
+    for e in $(ls $ENV_DIR); do
+      export "$e=$(cat $ENV_DIR/$e)"
+    done
+  fi
+}
+
 function export_mix_env() {
   if [ -z "$MIX_ENV" ]; then
     if [ -d $env_path ] && [ -f $env_path/MIX_ENV ]; then

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -46,17 +46,6 @@ function load_config() {
 }
 
 
-# Make the config vars from config_vars_to_export available at slug compile time.
-# Useful for compiled languages like Erlang and Elixir
-function export_config_vars() {
-  for config_var in ${config_vars_to_export[@]}; do
-    if [ -d $env_path ] && [ -f $env_path/${config_var} ]; then
-      export ${config_var}="$(cat $env_path/${config_var})"
-    fi
-  done
-}
-
-
 function export_default_env_vars() {
   whitelist_regex=${2:-''}
   blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -46,7 +46,7 @@ function load_config() {
 }
 
 
-function export_default_env_vars() {
+function export_env_vars() {
   whitelist_regex=${2:-''}
   blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
   if [ -d "$ENV_DIR" ]; then


### PR DESCRIPTION
Each variable is a file inside `$ENV_DIR` so we load them all up before calling `export_config_vars`
In the future this might need a blacklist of some sort.