### PR TITLE
Feature(procfile): using MIX_ENV=prod as default

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,5 +5,5 @@ cat <<EOF
 addons:
   []
 default_process_types:
-  web: mix run --no-halt
+  web: MIX_ENV=prod mix phoenix.server
 EOF


### PR DESCRIPTION
Not sure if this is correct, but it's the default way to run the server.
Not to mention you'd probably want the production environment, unless I'm missing something? 