### PR TITLE
Remove dangling references to config_vars_to_export from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 * **Easy configuration** with `elixir_buildpack.config` file
 * Use **prebuilt Elixir binaries**
-* `DATABASE_URL` can be made available at compile time adding it to `config_vars_to_export` in `elixir_buildpack.config`
 * Allows configuring Erlang
 * If your app doesn't have a Procfile, default web task `mix run --no-halt` will be run.
 * Consolidates protocols
@@ -70,7 +69,7 @@ runtime_path=/app
 
 
 #### Migrating from previous build pack
-the following has been deprecated:
+the following has been deprecated and should be removed from `elixir_buildpack.config`:
 ```
 # Export heroku config vars
 config_vars_to_export=(DATABASE_URL)
@@ -104,12 +103,6 @@ erlang_version=18.2.1
 
 ```
 heroku config:set MY_VAR=the_value
-```
-
-* Add the config vars you want to be exported in your `elixir_buildpack.config` file:
-
-```
-config_vars_to_export=(DATABASE_URL MY_VAR)
 ```
 
 ## Other notes


### PR DESCRIPTION
There were some references to `config_vars_to_export` in the `README.md` that didn't get cleaned up in the `export_env_vars` PR.