### PR TITLE
Copy entire .hex directory to build directory (#105)

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -29,7 +29,7 @@ function copy_hex() {
     full_hex_file_path=${HOME}/.mix/archives/hex.ez
   fi
 
-  cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
+  cp -R ${HOME}/.hex/ ${build_path}/.hex/
 
   output_section "Copying hex from $full_hex_file_path"
   cp -R $full_hex_file_path ${build_path}/.mix/archives


### PR DESCRIPTION
Due to registry changes in Hex 0.14.0, the entire `~/.hex` directory should now be copied. Since `registry.ets` would be still be copied, this change is backwards compatible.

See #105 and hexpm/hex@3105cfb19db25e30e93170e6689c6768195fb291.