### PR TITLE
Specify Hex and Rebar versions so downloads can be skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ erlang_version=18.2.1
 # Elixir version
 elixir_version=1.2.0
 
+# Hex version
+hex_version=0.17.1 # can also be "latest"
+
+# Rebar version
+rebar3_version=3.3.6 # can also be "latest"
+
 # Always rebuild from scratch on every deploy?
 always_rebuild=false
 

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,6 @@
 erlang_version=19.3
 elixir_version=1.4.2
+hex_version=latest
+rebar3_version=latest
 always_rebuild=false
 runtime_path=/app

--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -90,14 +90,22 @@ function backup_mix() {
 }
 
 function install_hex() {
-  output_section "Installing Hex"
-  mix local.hex --force
+  if [ "$hex_version" != "latest" ] && mix archive | grep --quiet -E "hex-$hex_version$"; then
+    output_section "Using cached Hex $hex_version"
+  else
+    output_section "Installing latest Hex"
+    mix local.hex --force
+  fi
 }
 
 function install_rebar() {
-  output_section "Installing rebar"
-
-  mix local.rebar --force
+  echo
+  if [ "$rebar3_version" != "latest" ] && [ -f ~/.mix/rebar3 ] && ~/.mix/rebar3 --version | grep --quiet -E "$rebar3_version "; then
+    output_section "Using cached Rebar $rebar3_version"
+  else
+    output_section "Installing latest Rebar from hex.pm"
+    mix local.rebar --force
+  fi
 }
 
 function elixir_changed() {


### PR DESCRIPTION
Currently by doing `--force` we always install latest version regardless if it was already present (due to cache) in `~/.mix/archives` or`~/.mix/rebar*`.

Such behaviour is preserved by defaulting config value to`"latest"`.