### PR TITLE
Move precompile hook and add hook before dependency fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ elixir_version=1.2.0
 # Always rebuild from scratch on every deploy?
 always_rebuild=false
 
+# A command to run right before fetching dependencies
+pre_fetch_dependencies="pwd"
+
 # A command to run right before compiling the app (after elixir, .etc)
 pre_compile="pwd"
 
@@ -125,6 +128,7 @@ heroku config:set MY_VAR=the_value
   ```
 
 * The buildpack will execute the commands configured in `pre_compile` and/or `post_compile` in the root directory of your application before/after it has been compiled (respectively). These scripts can be used to build or prepare things for your application, for example compiling assets.
+* The buildpack will execute the commands configured in `pre_fetch_dependencies` in the root directory of your application before it fetches the applicatoin dependencies. This script can be used to clean certain dependencies before fetching new ones.
 
 
 #### Using older version of buildpack

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Consolidates protocols
 * Hex and rebar support
 * Caching of Hex packages, Mix dependencies and downloads
-* Pre & Post compilation hooks through `pre_compile`, `post_compile` configuration
+* Pre & Post compilation hooks through `hook_pre_compile`, `hook_post_compile` configuration
 
 
 #### Version support
@@ -58,13 +58,13 @@ elixir_version=1.2.0
 always_rebuild=false
 
 # A command to run right before fetching dependencies
-pre_fetch_dependencies="pwd"
+hook_pre_fetch_dependencies="pwd"
 
 # A command to run right before compiling the app (after elixir, .etc)
-pre_compile="pwd"
+hook_pre_compile="pwd"
 
 # A command to run right after compiling the app
-post_compile="pwd"
+hook_post_compile="pwd"
 
 # Set the path the app is run from
 runtime_path=/app
@@ -127,8 +127,8 @@ heroku config:set MY_VAR=the_value
   end
   ```
 
-* The buildpack will execute the commands configured in `pre_compile` and/or `post_compile` in the root directory of your application before/after it has been compiled (respectively). These scripts can be used to build or prepare things for your application, for example compiling assets.
-* The buildpack will execute the commands configured in `pre_fetch_dependencies` in the root directory of your application before it fetches the applicatoin dependencies. This script can be used to clean certain dependencies before fetching new ones.
+* The buildpack will execute the commands configured in `hook_pre_compile` and/or `hook_post_compile` in the root directory of your application before/after it has been compiled (respectively). These scripts can be used to build or prepare things for your application, for example compiling assets.
+* The buildpack will execute the commands configured in `hook_pre_fetch_dependencies` in the root directory of your application before it fetches the applicatoin dependencies. This script can be used to clean certain dependencies before fetching new ones.
 
 
 #### Using older version of buildpack

--- a/bin/compile
+++ b/bin/compile
@@ -40,15 +40,17 @@ restore_mix
 install_hex
 install_rebar
 
-pre_compile_hook
 
 restore_app
 app_dependencies
 copy_hex
+
+pre_compile_hook
 compile_app
+post_compile_hook
+
 backup_app
 backup_mix
 write_profile_d_script
 write_export
 
-post_compile_hook

--- a/bin/compile
+++ b/bin/compile
@@ -40,18 +40,22 @@ restore_mix
 install_hex
 install_rebar
 
+# deprecated_hook, here for backwards compatibility
+pre_compile_hook
 
 restore_app
-pre_app_dependencies
+hook_pre_app_dependencies
 app_dependencies
 copy_hex
 
-pre_compile_hook
+hook_pre_compile
 compile_app
-post_compile_hook
+hook_post_compile
 
 backup_app
 backup_mix
 write_profile_d_script
 write_export
 
+# deprecated_hook, here for backwards compatibility
+post_compile_hook

--- a/bin/compile
+++ b/bin/compile
@@ -42,6 +42,7 @@ install_rebar
 
 
 restore_app
+pre_app_dependencies
 app_dependencies
 copy_hex
 

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -35,6 +35,16 @@ function copy_hex() {
   cp -R $full_hex_file_path ${build_path}/.mix/archives
 }
 
+function pre_app_dependencies() {
+  cd $build_path
+
+  if [ -n "$pre_fetch_dependencies" ]; then
+    output_section "Executing hook before fetching app dependencies: $pre_fetch_dependencies"
+    $pre_fetch_dependencies || exit 1
+  fi
+
+  cd - > /dev/null
+}
 
 function app_dependencies() {
   # Unset this var so that if the parent dir is a git repo, it isn't detected

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -35,12 +35,34 @@ function copy_hex() {
   cp -R $full_hex_file_path ${build_path}/.mix/archives
 }
 
-function pre_app_dependencies() {
+function hook_pre_app_dependencies() {
   cd $build_path
 
-  if [ -n "$pre_fetch_dependencies" ]; then
-    output_section "Executing hook before fetching app dependencies: $pre_fetch_dependencies"
-    $pre_fetch_dependencies || exit 1
+  if [ -n "$hook_pre_fetch_dependencies" ]; then
+    output_section "Executing hook before fetching app dependencies: $hook_pre_fetch_dependencies"
+    $hook_pre_fetch_dependencies || exit 1
+  fi
+
+  cd - > /dev/null
+}
+
+function hook_pre_compile() {
+  cd $build_path
+
+  if [ -n "$hook_pre_compile" ]; then
+    output_section "Executing hook before compile: $hook_pre_compile"
+    $hook_pre_compile || exit 1
+  fi
+
+  cd - > /dev/null
+}
+
+function hook_post_compile() {
+  cd $build_path
+
+  if [ -n "$hook_post_compile" ]; then
+    output_section "Executing hook after compile: $hook_post_compile"
+    $hook_post_compile || exit 1
   fi
 
   cd - > /dev/null
@@ -88,7 +110,7 @@ function post_compile_hook() {
   cd $build_path
 
   if [ -n "$post_compile" ]; then
-    output_section "Executing post compile: $post_compile"
+    output_section "Executing DEPRECATED post compile: $post_compile"
     $post_compile || exit 1
   fi
 
@@ -99,7 +121,7 @@ function pre_compile_hook() {
   cd $build_path
 
   if [ -n "$pre_compile" ]; then
-    output_section "Executing pre compile: $pre_compile"
+    output_section "Executing DEPRECATED pre compile: $pre_compile"
     $pre_compile || exit 1
   fi
 


### PR DESCRIPTION
We where unable to clean certain depencies during the build process, and where forced to add another hook:

`pre_fetch_dependencies`

This solves the current issue for us: 

https://github.com/appsignal/appsignal-elixir/issues/288