### PR TITLE
set env to current env rather than prod

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -138,7 +138,7 @@ function write_profile_d_script() {
   # Only write MIX_ENV to profile if the application did not set MIX_ENV
   if [ ! -f $env_path/MIX_ENV ]; then
     export_line="${export_line}
-                 export MIX_ENV=prod"
+                 export MIX_ENV=${MIX_ENV}"
   fi
 
   echo $export_line >> $build_path/.profile.d/elixir_buildpack_paths.sh
@@ -153,7 +153,7 @@ function write_export() {
   # Only write MIX_ENV to export if the application did not set MIX_ENV
   if [ ! -f $env_path/MIX_ENV ]; then
     export_line="${export_line}
-                 export MIX_ENV=prod"
+                 export MIX_ENV=${MIX_ENV}"
   fi
 
   echo $export_line > $build_pack_path/export


### PR DESCRIPTION
https://github.com/HashNuke/heroku-buildpack-elixir/commit/651bb3d24e9538e158858591499bbcb166ebbb94#diff-affe38b4efd476d398c0a64a202d07d0R156

this changed prod to default, where prior behavior was to write current env ( used in test_compile -> test flow )