### PR TITLE
Print download url's for erlang and elixir downloads

### DIFF
--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -7,9 +7,10 @@ function download_elixir() {
     elixir_changed=true
     local otp_version=$(otp_version ${erlang_version})
 
-    output_section "Fetching Elixir ${elixir_version} for OTP ${otp_version}"
-
     local download_url="https://repo.hex.pm/builds/elixir/${elixir_version}-otp-${otp_version}.zip"
+
+    output_section "Fetching Elixir ${elixir_version} for OTP ${otp_version} from ${download_url}"
+
     curl -s ${download_url} -o ${cache_path}/$(elixir_download_file)
 
     if [ $? -ne 0 ]; then

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -13,7 +13,7 @@ function download_erlang() {
     # Set this so elixir will be force-rebuilt
     erlang_changed=true
 
-    output_section "Fetching Erlang ${erlang_version}"
+    output_section "Fetching Erlang ${erlang_version} from ${erlang_package_url}"
     curl -s ${erlang_package_url} -o ${cache_path}/$(erlang_tarball) || exit 1
   else
     output_section "Using cached Erlang ${erlang_version}"


### PR DESCRIPTION
Printing the download url's to the output can aid in debugging any potential download issues.