### PR TITLE
Bump default elixir_version to 1.5.3 to include bug fixes

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
 erlang_version=20.1
-elixir_version=1.5.0
+elixir_version=1.5.3
 always_rebuild=false
 runtime_path=/app


### PR DESCRIPTION
Hello :)

I noticed that the default version of elixir is set to `1.5.0` which includes a bug that is noticeable when trying to to deploy a phoenix application:
```
2019-01-03T15:38:37.053305+00:00 app[web.1]: ** (ArgumentError) supervisors expect the child to be a module, a {module, arg} tuple or a map with the child specification, got: {DBConnection.ConnectionPool, {Ecto.Repo.Supervisor, :start_child, [{DBConnection.ConnectionPool, :start_link, [{Postgrex.Protocol, [types: Postgrex.DefaultTypes, repo: PhxHerokuExample.Repo, telemetry_prefix: [:phx_heroku_example, :repo], otp_app: :phx_heroku_example, timeout: 15000, pool_size: 18, ssl: true, username: "yzmhjpskdlwfjb", password: "3ee7f832e5fa8e23d7b83aa6694890876fd837177a5eede0a7346a346fdbe9bc", database: "dltactb6m7fkm", hostname: "ec2-50-16-201-73.compute-1.amazonaws.com", port: 5432, pool: DBConnection.ConnectionPool]}]}, Ecto.Adapters.Postgres, #Reference<0.831229503.1173487617.25711>, %{opts: [timeout: 15000, pool_size: 18, pool: DBConnection.ConnectionPool], sql: Ecto.Adapters.Postgres.Connection, telemetry: {:debug, [], [:phx_heroku_example, :repo, :query]}}]}, :permanent, 5000, :worker, [DBConnection.ConnectionPool]}
```

Based on the conversation in https://elixirforum.com/t/ecto-migration-fails-on-heroku/18112, I believe the issue is the version `1.5.0`.

The problem appears to be fixed with the bump to `1.5.3`. This PR bumps the version to avoid the original issue I encountered for anyone trying to deploy a phoenix application with the default elixir version.