### PR TITLE
add Elixir releases support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ elixir_version=1.2.0
 # Always rebuild from scratch on every deploy?
 always_rebuild=false
 
+# Create a release using `mix release`? (requires Elixir 1.9)
+release=true
+
 # A command to run right before fetching dependencies
 hook_pre_fetch_dependencies="pwd"
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ The above method always uses the latest version of the buildpack code. To use a 
 
 This buildpack supports Heroku CI. To enable viewing test runs on Heroku, add [tapex](https://github.com/joshwlewis/tapex) to your project.
 
+#### Elixir Releases
+
+This buildpack can optionally build an [Elixir release](https://hexdocs.pm/mix/Mix.Tasks.Release.html). The release build will be run after `hook_post_compile`.
+
+To build and use a release for an app called `foo` compiled with `MIX_ENV=prod`:
+1. Make sure `elixir_version` in `elixir_buildpack.config` is at least 1.9
+2. Add `release=true` to `elixir_buildpack.config`
+3. Use `web: _build/prod/rel/foo/bin/foo start` in your Procfile
+
+If you need to do further compilation using another buildpack, such as the [Phoenix static buildpack](https://github.com/gjaldon/heroku-buildpack-phoenix-static), you will need a more modular solution. See the [Elixir release buildpack](https://github.com/chrismcg/heroku-buildpack-elixir-mix-release) instead.
+
 ## Configuration
 
 Create a `elixir_buildpack.config` file in your app's root dir. The file's syntax is bash.

--- a/bin/compile
+++ b/bin/compile
@@ -50,8 +50,9 @@ copy_hex
 
 hook_pre_compile
 compile_app
-release_app
 hook_post_compile
+
+release_app
 
 backup_app
 backup_mix

--- a/bin/compile
+++ b/bin/compile
@@ -50,6 +50,7 @@ copy_hex
 
 hook_pre_compile
 compile_app
+release_app
 hook_post_compile
 
 backup_app

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -106,6 +106,17 @@ function compile_app() {
   cd - > /dev/null
 }
 
+function release_app() {
+  cd $build_path
+
+  if [ $release = true ]; then
+    output_section "Building release"
+    mix release --overwrite
+  fi
+
+  cd - > /dev/null
+}
+
 function post_compile_hook() {
   cd $build_path
 


### PR DESCRIPTION
[Elixir 1.9](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/) introduced `mix release`. This is a huge improvement for Heroku based deployments because the slug can be compiled once and then deployed to different apps with different configs which will be read at runtime.

This PR adds a new option to build the default release on top of the usual compilation process. After the slug is compiled the release can be run by having `web: _build/prod/rel/{app_name}/bin/{app_name} start`. We at Tallarium already use this setup in all our Elixir Heroku apps.