### PR TITLE
Friendly error message when erlang version is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ We only create a new tag/release when we've made breaking changes. So consider a
 * Build scripts to build erlang are at <https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds>
 * Sample app to test is available at <https://github.com/HashNuke/heroku-buildpack-elixir-test>
 
+## Testing
+
+To run tests
+```
+git clone https://github.com/HashNuke/heroku-buildpack-elixir
+export BUILDPACK="$(pwd)/heroku-buildpack-elixir"
+git clone https://github.com/jesseshieh/heroku-buildpack-testrunner
+git clone https://github.com/kward/shunit2
+export SHUNIT_HOME="$(pwd)/shunit2"
+cd heroku-buildpack-testrunner
+bin/run $BUILDPACK
+```
+
+See more info at https://github.com/jesseshieh/heroku-buildpack-testrunner/blob/master/README.md
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To run tests
 git clone https://github.com/HashNuke/heroku-buildpack-elixir
 export BUILDPACK="$(pwd)/heroku-buildpack-elixir"
 git clone https://github.com/jesseshieh/heroku-buildpack-testrunner
-git clone https://github.com/kward/shunit2
+git clone https://github.com/jesseshieh/shunit2
 export SHUNIT_HOME="$(pwd)/shunit2"
 cd heroku-buildpack-testrunner
 bin/run $BUILDPACK

--- a/bin/compile
+++ b/bin/compile
@@ -25,6 +25,7 @@ source ${build_pack_path}/lib/app_funcs.sh
 mkdir $(platform_tools_path)
 
 load_config
+check_erlang_version "$erlang_version"
 export_env_vars
 export_mix_env
 

--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,7 @@ source ${build_pack_path}/lib/misc_funcs.sh
 source ${build_pack_path}/lib/erlang_funcs.sh
 source ${build_pack_path}/lib/elixir_funcs.sh
 source ${build_pack_path}/lib/app_funcs.sh
+source ${build_pack_path}/lib/canonical_version.sh
 
 mkdir $(platform_tools_path)
 

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -1,0 +1,4 @@
+canonicalVersion() {
+  version=$1
+  echo $version
+}

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -1,4 +1,28 @@
-canonicalVersion() {
-  version=$1
-  echo $version
+#!/usr/bin/env bash
+
+fetch_erlang_versions() {
+  url="https://raw.githubusercontent.com/HashNuke/heroku-buildpack-elixir-otp-builds/master/otp-versions"
+  curl -s "$url" 
 }
+
+exact_erlang_version_available() {
+  version=$1
+  available_versions=$2
+  found=1
+  while read -r line; do
+    if [ "$line" = "$version" ]; then
+      found=0
+    fi
+  done <<< "$available_versions"
+  echo $found
+}
+
+check_erlang_version() {
+  version=$1
+  exists=$(exact_erlang_version_available "$version" "$(fetch_erlang_versions)")
+  if [ $exists -ne 0 ]; then
+    output_line "Sorry, Erlang $version isn't supported yet. For a list of supported versions, please see https://github.com/HashNuke/heroku-buildpack-elixir#version-support"
+    exit 1
+  fi
+}
+

--- a/test/canonical_version_test.sh
+++ b/test/canonical_version_test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+. ${BUILDPACK_HOME}/lib/canonical_version.sh
+
+testEquality() {
+  assertEquals 1 1
+}
+
+testExactVersion() {
+  newVersion=$(canonicalVersion 1.2.3)
+  assertEquals $newVersion 1.2.3
+}
+
+
+

--- a/test/canonical_version_test.sh
+++ b/test/canonical_version_test.sh
@@ -20,11 +20,3 @@ testExactErlangVersionMajorOnly() {
 testExactErlangVersionMajorMinorOnly() {
   assertEquals 0 $(exact_erlang_version_available "21.0" "$VERSIONS")
 }
-
-
-
-
-
-
-
-

--- a/test/canonical_version_test.sh
+++ b/test/canonical_version_test.sh
@@ -1,16 +1,30 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
 . ${BUILDPACK_HOME}/lib/canonical_version.sh
 
-testEquality() {
-  assertEquals 1 1
+VERSIONS=$(fetch_erlang_versions)
+
+testExactErlangVersionAvailable() {
+  assertEquals 0 $(exact_erlang_version_available "22.0.3" "$VERSIONS")
 }
 
-testExactVersion() {
-  newVersion=$(canonicalVersion 1.2.3)
-  assertEquals $newVersion 1.2.3
+testExactErlangVersionUnavailable() {
+  assertEquals 1 $(exact_erlang_version_available "22.0.1" "$VERSIONS")
 }
+
+testExactErlangVersionMajorOnly() {
+  assertEquals 1 $(exact_erlang_version_available "21" "$VERSIONS")
+}
+
+testExactErlangVersionMajorMinorOnly() {
+  assertEquals 0 $(exact_erlang_version_available "21.0" "$VERSIONS")
+}
+
+
+
+
+
 
 
 


### PR DESCRIPTION
Addresses part of #156

I'll submit another pull request that can "alter" the version to the most recent patch if a patch is not specified.