### PR TITLE
Allow additional test arguments as config vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ hook_post_compile="pwd"
 
 # Set the path the app is run from
 runtime_path=/app
+
+# Enable or disable additional test arguments
+test_args="--cover"
 ```
 
 
@@ -143,7 +146,7 @@ heroku config:set MY_VAR=the_value
   ```
 
 * The buildpack will execute the commands configured in `hook_pre_compile` and/or `hook_post_compile` in the root directory of your application before/after it has been compiled (respectively). These scripts can be used to build or prepare things for your application, for example compiling assets.
-* The buildpack will execute the commands configured in `hook_pre_fetch_dependencies` in the root directory of your application before it fetches the applicatoin dependencies. This script can be used to clean certain dependencies before fetching new ones.
+* The buildpack will execute the commands configured in `hook_pre_fetch_dependencies` in the root directory of your application before it fetches the application dependencies. This script can be used to clean certain dependencies before fetching new ones.
 
 
 #### Using older version of buildpack

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cd "$1" && mix test
+cd "$1" && mix test ${test_args}


### PR DESCRIPTION
Right now you can't do things like add a coverage report or specify which folders to constrain the testing to. This additional config var, when present, will simply be added to the end of `mix test`. If it is not present, or the value is an empty string, then `mix test` will execute normally (i.e. as though no arguments were passed to it).

I've tested this locally and (a) when using the default config it works and (b) when setting `test_args="--cover"` to the config it properly generate the code coverage report.