### PR TITLE
load config after loading env vars so that they can be used in hooks.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,10 +25,10 @@ source ${build_pack_path}/lib/canonical_version.sh
 
 mkdir $(platform_tools_path)
 
-load_config
 check_erlang_version "$erlang_version"
 export_env_vars
 export_mix_env
+load_config
 
 check_stack
 clean_cache

--- a/bin/compile
+++ b/bin/compile
@@ -25,10 +25,10 @@ source ${build_pack_path}/lib/canonical_version.sh
 
 mkdir $(platform_tools_path)
 
-check_erlang_version "$erlang_version"
 export_env_vars
 export_mix_env
 load_config
+check_erlang_version "$erlang_version"
 
 check_stack
 clean_cache


### PR DESCRIPTION
While trying to use private hex repositories. We tried using the `hook_pre_fetch_dependencies` option like this
```
hook_pre_fetch_dependencies="mix hex.organization auth foo --key ${KEY}"
```

But this didn't work, because `${KEY}` is not available before configs are loaded. This change makes it so that env vars are available before the config file is sourced.