### PR TITLE
Allow setting a custom compilation command using `hook_compile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 * Consolidates protocols
 * Hex and rebar support
 * Caching of Hex packages, Mix dependencies and downloads
-* Pre & Post compilation hooks through `hook_pre_compile`, `hook_post_compile` configuration
-
+* Compilation procedure hooks through `hook_pre_compile`, `hook_compile`, `hook_post_compile` configuration
 
 #### Version support
 
@@ -51,7 +50,10 @@ The above method always uses the latest version of the buildpack code. To use a 
 
 #### Using Heroku CI
 
-This buildpack supports Heroku CI. To enable viewing test runs on Heroku, add [tapex](https://github.com/joshwlewis/tapex) to your project.
+This buildpack supports Heroku CI. 
+
+* To enable viewing test runs on Heroku, add [tapex](https://github.com/joshwlewis/tapex) to your project.
+* To detect compilation warnings use the `hook_compile` configuration option set to `mix compile --force --warnings-as-errors`.
 
 ## Configuration
 
@@ -77,6 +79,8 @@ hook_pre_fetch_dependencies="pwd"
 
 # A command to run right before compiling the app (after elixir, .etc)
 hook_pre_compile="pwd"
+
+hook_compile="mix compile --force --warnings-as-errors"
 
 # A command to run right after compiling the app
 hook_post_compile="pwd"

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -101,7 +101,13 @@ function compile_app() {
 
   cd $build_path
   output_section "Compiling"
-  mix compile --force || exit 1
+
+  if [ -n "$hook_compile" ]; then
+     output_section "(using custom compile command)"
+     $hook_compile || exit 1
+  else
+     mix compile --force || exit 1
+  fi
 
   mix deps.clean --unused
 


### PR DESCRIPTION
## Description

Allow setting a custom compilation command using `hook_compile`. See [changed README.md file](https://github.com/HashNuke/heroku-buildpack-elixir/commit/dab040b2c4d6648255bee41b920adcbe1fd480cc) for more details.

## Example use cases:

* common: add ` --warnings-as-errors` flag to `mix compile` while in Heroku CI to check that the compilation does not have any warnings
* very rare: run the compilation in a single thread (fixes multi-threading compilation issues with some code bases – as temporary solution before fixing the root cause of such problems)

In @socialpaymentsbv we use this patch in the above 2 use cases for [2 months now](https://github.com/socialpaymentsbv/heroku-buildpack-elixir/pull/1).

## Testing

Tests were ran and the result was:

```sh
git clone https://github.com/socialpaymentsbv/heroku-buildpack-elixir.git
(cd heroku-buildpack-elixir; git fetch; git checkout add-compilation-hook)
export BUILDPACK="$(pwd)/heroku-buildpack-elixir"
git clone https://github.com/jesseshieh/heroku-buildpack-testrunner
git clone https://github.com/jesseshieh/shunit2
export SHUNIT_HOME="$(pwd)/shunit2"
(cd heroku-buildpack-testrunner; bin/run $BUILDPACK)

BUILDPACK: ~/cc/src/tmp/heroku-buildpack-elixir
  TEST SUITE: canonical_version_test.sh
  testExactErlangVersionAvailable
  testExactErlangVersionUnavailable
  testExactErlangVersionMajorOnly
  testExactErlangVersionMajorMinorOnly
  
  Ran 4 tests.
  
  OK
  1 SECONDS

1 SECONDS

------
ALL OK
1 SECONDS
```