### PR TITLE
strip out non-digit non-dot characters on version string, for example…

### DIFF
--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -53,6 +53,9 @@ function fix_elixir_version() {
 
     # If we detect a version string (e.g. 1.14 or 1.14.0) we prefix it with "v"
     if [[ ${elixir_version} =~ ^[0-9]+\.[0-9]+ ]]; then
+      # strip out any non-digit non-dot characters
+      # TODO: what about ^M for non-version strings?
+      elixir_version=$(echo "$elixir_version" | sed 's/[^0-9.]*//g')
       elixir_version=v${elixir_version}
     fi
 

--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -1,6 +1,4 @@
 function download_elixir() {
-  fix_elixir_version
-
   # If a previous download does not exist, then always re-download
   if [ ${force_fetch} = true ] || [ ! -f ${cache_path}/$(elixir_download_file) ]; then
     clean_elixir_downloads
@@ -41,30 +39,6 @@ function install_elixir() {
   PATH=$(elixir_path)/bin:${PATH}
 
   export LC_CTYPE=en_US.utf8
-}
-
-function fix_elixir_version() {
-  if [ ${#elixir_version[@]} -eq 2 ] && [ ${elixir_version[0]} = "branch" ]; then
-    force_fetch=true
-    elixir_version=${elixir_version[1]}
-
-  elif [ ${#elixir_version[@]} -eq 1 ]; then
-    force_fetch=false
-
-    # If we detect a version string (e.g. 1.14 or 1.14.0) we prefix it with "v"
-    if [[ ${elixir_version} =~ ^[0-9]+\.[0-9]+ ]]; then
-      # strip out any non-digit non-dot characters
-      # TODO: what about ^M for non-version strings?
-      elixir_version=$(echo "$elixir_version" | sed 's/[^0-9.]*//g')
-      elixir_version=v${elixir_version}
-    fi
-
-  else
-    output_line "Invalid Elixir version specified"
-    output_line "See the README for allowed formats at:"
-    output_line "https://github.com/HashNuke/heroku-buildpack-elixir"
-    exit 1
-  fi
 }
 
 function elixir_download_file() {

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -107,8 +107,7 @@ function fix_erlang_version() {
 }
 
 function fix_elixir_version() {
-  # Strip out ^M which messes up bash arrays here
-  elixir_version=$(echo "$elixir_version" | sed 's///g')
+  # TODO: this breaks if there is an carriage return behind elixir_version=(branch master)^M
   if [ ${#elixir_version[@]} -eq 2 ] && [ ${elixir_version[0]} = "branch" ]; then
     force_fetch=true
     elixir_version=${elixir_version[1]}

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -103,9 +103,7 @@ function clear_cached_files() {
 }
 
 function fix_erlang_version() {
-  output_line "$erlang_version"
   erlang_version=$(echo "$erlang_version" | sed 's/[^0-9.]*//g')
-  output_line "$erlang_version"
 }
 
 function fix_elixir_version() {

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -37,6 +37,9 @@ function load_config() {
     output_line "Using default config from Elixir buildpack"
   fi
 
+  fix_erlang_version
+  fix_elixir_version
+
   output_line "Will use the following versions:"
   output_line "* Stack ${STACK}"
   output_line "* Erlang ${erlang_version}"
@@ -98,3 +101,32 @@ function clear_cached_files() {
     $(mix_backup_path) \
     $(hex_backup_path)
 }
+
+function fix_erlang_version() {
+  erlang_version=$(echo "$erlang_version" | sed 's/[^0-9.]*//g')
+}
+
+function fix_elixir_version() {
+  if [ ${#elixir_version[@]} -eq 2 ] && [ ${elixir_version[0]} = "branch" ]; then
+    force_fetch=true
+    elixir_version=${elixir_version[1]}
+
+  elif [ ${#elixir_version[@]} -eq 1 ]; then
+    force_fetch=false
+
+    # If we detect a version string (e.g. 1.14 or 1.14.0) we prefix it with "v"
+    if [[ ${elixir_version} =~ ^[0-9]+\.[0-9]+ ]]; then
+      # strip out any non-digit non-dot characters
+      # TODO: what about ^M for non-version strings?
+      elixir_version=$(echo "$elixir_version" | sed 's/[^0-9.]*//g')
+      elixir_version=v${elixir_version}
+    fi
+
+  else
+    output_line "Invalid Elixir version specified"
+    output_line "See the README for allowed formats at:"
+    output_line "https://github.com/HashNuke/heroku-buildpack-elixir"
+    exit 1
+  fi
+}
+

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -107,6 +107,8 @@ function fix_erlang_version() {
 }
 
 function fix_elixir_version() {
+  # Strip out ^M which messes up bash arrays here
+  elixir_version=$(echo "$elixir_version" | sed 's///g')
   if [ ${#elixir_version[@]} -eq 2 ] && [ ${elixir_version[0]} = "branch" ]; then
     force_fetch=true
     elixir_version=${elixir_version[1]}
@@ -117,7 +119,6 @@ function fix_elixir_version() {
     # If we detect a version string (e.g. 1.14 or 1.14.0) we prefix it with "v"
     if [[ ${elixir_version} =~ ^[0-9]+\.[0-9]+ ]]; then
       # strip out any non-digit non-dot characters
-      # TODO: what about ^M for non-version strings?
       elixir_version=$(echo "$elixir_version" | sed 's/[^0-9.]*//g')
       elixir_version=v${elixir_version}
     fi

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -103,7 +103,9 @@ function clear_cached_files() {
 }
 
 function fix_erlang_version() {
+  output_line "$erlang_version"
   erlang_version=$(echo "$erlang_version" | sed 's/[^0-9.]*//g')
+  output_line "$erlang_version"
 }
 
 function fix_elixir_version() {


### PR DESCRIPTION
… ^M, which many customers have run into.