### PR TITLE
Support heroku-20 and gigalixir-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,20 @@
 #### Version support
 
 * Erlang - Prebuilt packages (17.5, 17.4, etc)
-  * The full list of prebuilt packages can be found here: https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-  * Note: if a version you want is missing then you can create a PR that adds it
+  * The full list of prebuilt packages can be found here: 
+    * gigalixir-20 or heroku-20 stacks: https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt
+    * All other stacks: https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
 * Elixir - Prebuilt releases (1.0.4, 1.0.3, etc) or prebuilt branches (master, v1.7, etc)
   * The full list of releases can be found here: https://github.com/elixir-lang/elixir/releases
   * The full list of branches can be found here: https://github.com/elixir-lang/elixir/branches
 
 Note: you should choose an Elixir and Erlang version that are [compatible with one another](https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp).
 
-#### Heroku 20 and Cloud Native Support
+#### Cloud Native Support
 
-* Heroku 20 users should use [this buildpack](https://github.com/elixir-buildpack/heroku-buildpack)
 * Cloud Native users should use [this buildpack](https://github.com/elixir-buildpack/cloud-native-buildpack)
 
-**This buildpack does not support Heroku 20 and is not Cloud Native compatible.** This buildpack uses Erlang OTP releases that are compiled on
-the Cedar 14 stack. As a result, it does not support the Heroku 20 stack and is compiled using older versions of some libraries (such as OpenSSL).
-The [elixir-buildpack/heroku-buildpack](https://github.com/elixir-buildpack/heroku-buildpack) is a fork of this buildpack that uses versions of OTP
-that are compiled on a [new build system](https://github.com/elixir-buildpack/heroku-otp) that compiles OTP on the Heroku Docker images for each stack (16, 18, 20).
+**This buildpack is not guaranteed to be Cloud Native compatible.** 
 The [elixir-buildpack/cloud-native-buildpack](https://github.com/elixir-buildpack/cloud-native-buildpack) is a buildpack that is actively under development
 and is designed specifically to follow the Cloud Native Buildpack conventions.
 

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -1,24 +1,26 @@
 #!/usr/bin/env bash
 
 erlang_builds_url() {
-  # TODO: use ubuntu-20.04 if applicable
-  # use new STACK env var: STACK=heroku-20
-  erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
+  if [ "$STACK" = "heroku-20" ]; then
+    erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
+  else
+    erlang_builds_url="https://s3.amazonaws.com/heroku-buildpack-elixir/erlang/cedar-14"
+  fi
   echo $erlang_builds_url
 }
 
-erlang_versions_url() {
-  # TODO: use ubuntu-20.04 if applicable
-  # TODO: fallback to hashnuke one if not ubuntu-20.04 and not found on hex
-  url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
-  echo $url
-}
-
 fetch_erlang_versions() {
-  curl -s "$(erlang_versions_url)" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}' | sort
+  if [ "$STACK" = "heroku-20" ]; then
+    url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
+    curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
+  else
+    url="https://raw.githubusercontent.com/HashNuke/heroku-buildpack-elixir-otp-builds/master/otp-versions"
+    curl -s "$url"
+  fi
 }
 
 exact_erlang_version_available() {
+  # TODO: fallback to hashnuke one if not ubuntu-20.04 and not found on hex
   version=$1
   available_versions=$2
   found=1
@@ -34,7 +36,7 @@ check_erlang_version() {
   version=$1
   exists=$(exact_erlang_version_available "$version" "$(fetch_erlang_versions)")
   if [ $exists -ne 0 ]; then
-    output_line "Sorry, Erlang $version isn't supported yet. For a list of supported versions, please see $(erlang_versions_url)"
+    output_line "Sorry, Erlang $version isn't supported yet. For a list of supported versions, please see https://github.com/HashNuke/heroku-buildpack-elixir#version-support"
     exit 1
   fi
 }

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 
+erlang_builds_url() {
+  # TODO: use ubuntu-20.04 if applicable
+  # use new STACK env var: STACK=heroku-20
+  erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
+  echo $erlang_builds_url
+}
+
+erlang_versions_url() {
+  # TODO: use ubuntu-20.04 if applicable
+  # TODO: fallback to hashnuke one if not ubuntu-20.04 and not found on hex
+  url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
+  echo $url
+}
+
 fetch_erlang_versions() {
-  url="https://raw.githubusercontent.com/HashNuke/heroku-buildpack-elixir-otp-builds/master/otp-versions"
-  curl -s "$url" 
+  curl -s "$(erlang_versions_url)" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}' | sort
 }
 
 exact_erlang_version_available() {
@@ -21,7 +34,7 @@ check_erlang_version() {
   version=$1
   exists=$(exact_erlang_version_available "$version" "$(fetch_erlang_versions)")
   if [ $exists -ne 0 ]; then
-    output_line "Sorry, Erlang $version isn't supported yet. For a list of supported versions, please see https://github.com/HashNuke/heroku-buildpack-elixir#version-support"
+    output_line "Sorry, Erlang $version isn't supported yet. For a list of supported versions, please see $(erlang_versions_url)"
     exit 1
   fi
 }

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -3,8 +3,7 @@ function erlang_tarball() {
 }
 
 function download_erlang() {
-  erlang_package_url="https://s3.amazonaws.com/heroku-buildpack-elixir/erlang/cedar-14"
-  erlang_package_url="${erlang_package_url}/$(erlang_tarball)"
+  erlang_package_url="$(erlang_builds_url)/$(erlang_tarball)"
 
   # If a previous download does not exist, then always re-download
   if [ ! -f ${cache_path}/$(erlang_tarball) ]; then


### PR DESCRIPTION
Uses hex's otp builds for heroku-20 and gigalixir-20 and continues using the same builds for all other stacks. Eventually, we'll try to migrate all builds to hex's.

@KazW do you mind taking a look at this?