### PR TITLE
fix compatibilities when BUILD_DIR argument is /app

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -17,6 +17,12 @@ function copy_hex() {
   mkdir -p ${build_path}/.mix/archives
   mkdir -p ${build_path}/.hex
 
+  # copying hex is not necessary on the new build system,
+  # which builds in /app (which is the same as $HOME)
+  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194
+  if [ ${HOME} == ${build_path} ]; then
+    return 0
+  fi
 
   # hex is a directory from elixir-1.3.0
   full_hex_file_path=$(ls -dt ${HOME}/.mix/archives/hex-* | head -n 1)

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -35,7 +35,13 @@ function install_erlang() {
   ln -s $(erlang_build_path) $(runtime_erlang_path)
   $(erlang_build_path)/Install -minimal $(runtime_erlang_path)
 
-  cp -R $(erlang_build_path) $(erlang_path)
+  # only copy if using old build system;
+  # newer versions of the build system run builds with BUILD_PATH=/app
+  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194#issuecomment-800425532
+  if [ "${erlang_path}" != "${runtime_erlang_path}" ]; then
+    cp -R $(erlang_build_path) $(erlang_path)
+  fi
+
   PATH=$(erlang_path)/bin:$PATH
 }
 


### PR DESCRIPTION
fixes #194

Newer versions of the Heroku build system build the app in `/app` rather
than a tmp directory. If this is the case (the BUILD_DIR argument is the
same as `/app`), don't copy hex or other files over as they are already
in place.

https://github.com/HashNuke/heroku-buildpack-elixir/issues/194#issuecomment-800425532