### PR TITLE
place all stack-dependent cache folders under one root folder

### DIFF
--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -1,6 +1,8 @@
 function download_elixir() {
   # If a previous download does not exist, then always re-download
-  if [ ${force_fetch} = true ] || [ ! -f ${cache_path}/$(elixir_download_file) ]; then
+  mkdir -p $(elixir_cache_path)
+
+  if [ ${force_fetch} = true ] || [ ! -f $(elixir_cache_path)/$(elixir_download_file) ]; then
     clean_elixir_downloads
     elixir_changed=true
     local otp_version=$(otp_version ${erlang_version})
@@ -9,12 +11,12 @@ function download_elixir() {
 
     output_section "Fetching Elixir ${elixir_version} for OTP ${otp_version} from ${download_url}"
 
-    curl -s ${download_url} -o ${cache_path}/$(elixir_download_file)
+    curl -s ${download_url} -o $(elixir_cache_path)/$(elixir_download_file)
 
     if [ $? -ne 0 ]; then
       output_section "Falling back to fetching Elixir ${elixir_version} for generic OTP version"
       local download_url="https://repo.hex.pm/builds/elixir/${elixir_version}.zip"
-      curl -s ${download_url} -o ${cache_path}/$(elixir_download_file) || exit 1
+      curl -s ${download_url} -o $(elixir_cache_path)/$(elixir_download_file) || exit 1
     fi
   else
     output_section "Using cached Elixir ${elixir_version}"
@@ -28,9 +30,9 @@ function install_elixir() {
   cd $(elixir_path)
 
   if type "unzip" &> /dev/null; then
-    unzip -q ${cache_path}/$(elixir_download_file)
+    unzip -q $(elixir_cache_path)/$(elixir_download_file)
   else
-    jar xf ${cache_path}/$(elixir_download_file)
+    jar xf $(elixir_cache_path)/$(elixir_download_file)
   fi
 
   cd - > /dev/null
@@ -47,7 +49,8 @@ function elixir_download_file() {
 }
 
 function clean_elixir_downloads() {
-  rm -rf ${cache_path}/elixir*.zip
+  rm -rf $(elixir_cache_path)
+  mkdir -p $(elixir_cache_path)
 }
 
 function restore_mix() {

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -5,22 +5,24 @@ function erlang_tarball() {
 function download_erlang() {
   erlang_package_url="$(erlang_builds_url)/$(erlang_tarball)"
 
+  mkdir -p $(erlang_cache_path)
   # If a previous download does not exist, then always re-download
-  if [ ! -f ${cache_path}/$(erlang_tarball) ]; then
+  if [ ! -f $(erlang_cache_path)/$(erlang_tarball) ]; then
     clean_erlang_downloads
 
     # Set this so elixir will be force-rebuilt
     erlang_changed=true
 
     output_section "Fetching Erlang ${erlang_version} from ${erlang_package_url}"
-    curl -s ${erlang_package_url} -o ${cache_path}/$(erlang_tarball) || exit 1
+    curl -s ${erlang_package_url} -o $(erlang_cache_path)/$(erlang_tarball) || exit 1
   else
     output_section "Using cached Erlang ${erlang_version}"
   fi
 }
 
 function clean_erlang_downloads() {
-  rm -rf ${cache_path}/OTP-*.tar.gz
+  rm -rf $(erlang_cache_path)
+  mkdir -p $(erlang_cache_path)
 }
 
 function install_erlang() {
@@ -28,7 +30,7 @@ function install_erlang() {
 
   rm -rf $(erlang_build_path)
   mkdir -p $(erlang_build_path)
-  tar zxf ${cache_path}/$(erlang_tarball) -C $(erlang_build_path) --strip-components=1
+  tar zxf $(erlang_cache_path)/$(erlang_tarball) -C $(erlang_build_path) --strip-components=1
 
   rm -rf $(runtime_erlang_path)
   mkdir -p $(runtime_platform_tools_path)

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -25,10 +25,10 @@ function output_warning() {
   echo -e "${spacing} \e[31m$1\e[0m"
 }
 
-function output_stderr() { 
+function output_stderr() {
   # Outputs to stderr in case it is inside a function so it does not
   # disturb the return value. Useful for debugging.
-  echo "$@" 1>&2; 
+  echo "$@" 1>&2;
 }
 
 
@@ -115,7 +115,23 @@ function check_stack() {
   echo "${STACK}" > "${cache_path}/stack"
 }
 
+# remove any cache files that are not under the stack-based
+# cache directory specified by the `stack_based_cache_path`
+# function
+function clean_old_cache_files() {
+  rm -rf \
+    $(erlang_build_path) \
+    ${cache_path}/deps_backup \
+    ${cache_path}/build_backup \
+    ${cache_path}/.mix \
+    ${cache_path}/.hex
+  rm -rf ${cache_path}/OTP-*.zip
+  rm -rf ${cache_path}/elixir*.zip
+}
+
 function clean_cache() {
+  clean_old_cache_files
+
   if [ $always_rebuild = true ]; then
     output_section "Cleaning all cache to force rebuilds"
     $(clear_cached_files)
@@ -123,12 +139,7 @@ function clean_cache() {
 }
 
 function clear_cached_files() {
-  rm -rf \
-    $(erlang_build_path) \
-    $(deps_backup_path) \
-    $(build_backup_path) \
-    $(mix_backup_path) \
-    $(hex_backup_path)
+  rm -rf $(stack_based_cache_path)
 }
 
 function fix_erlang_version() {

--- a/lib/path_funcs.sh
+++ b/lib/path_funcs.sh
@@ -38,18 +38,30 @@ function erlang_build_path() {
   echo "${tmp_erlang_build_dir}/erlang"
 }
 
+function stack_based_cache_path() {
+  echo "${cache_path}/heroku-buildpack-elixir/stack-cache"
+}
+
 function deps_backup_path() {
-  echo $cache_path/deps_backup
+  echo $(stack_based_cache_path)/deps_backup
 }
 
 function build_backup_path() {
-  echo $cache_path/build_backup
+  echo $(stack_based_cache_path)/build_backup
 }
 
 function mix_backup_path() {
-  echo $cache_path/.mix
+  echo $(stack_based_cache_path)/.mix
 }
 
 function hex_backup_path() {
-  echo $cache_path/.hex
+  echo $(stack_based_cache_path)/.hex
+}
+
+function erlang_cache_path() {
+  echo $(stack_based_cache_path)/erlang
+}
+
+function elixir_cache_path() {
+  echo $(stack_based_cache_path)/elixir
 }


### PR DESCRIPTION
This way the cache can be reliably cleared without having to maintain a list of all the different cache directories between multiple files.

The erlang cache wasn't changing when the stack changed due to the `clean_cache` not knowing that there were files for Erlang in `${cache_path}/OTP-*.zip` (and elixir in `${cache_path}/elixir*.zip`) .

This also adds a `elixir_cache_path` and a `erlang_cache_path` functions for allowing us to keep to track of the Elixir/Erlang caches in one central place.

fixes #197
