### PR TITLE
Revert "fix compatibilities when BUILD_DIR argument is /app"

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -17,12 +17,6 @@ function copy_hex() {
   mkdir -p ${build_path}/.mix/archives
   mkdir -p ${build_path}/.hex
 
-  # copying hex is not necessary on the new build system,
-  # which builds in /app (which is the same as $HOME)
-  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194
-  if [ ${HOME} == ${build_path} ]; then
-    return 0
-  fi
 
   # hex is a directory from elixir-1.3.0
   full_hex_file_path=$(ls -dt ${HOME}/.mix/archives/hex-* | head -n 1)

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -37,13 +37,7 @@ function install_erlang() {
   ln -s $(erlang_build_path) $(runtime_erlang_path)
   $(erlang_build_path)/Install -minimal $(runtime_erlang_path)
 
-  # only copy if using old build system;
-  # newer versions of the build system run builds with BUILD_PATH=/app
-  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194#issuecomment-800425532
-  if [ "${erlang_path}" != "${runtime_erlang_path}" ]; then
-    cp -R $(erlang_build_path) $(erlang_path)
-  fi
-
+  cp -R $(erlang_build_path) $(erlang_path)
   PATH=$(erlang_path)/bin:$PATH
 }
 


### PR DESCRIPTION
Reverts HashNuke/heroku-buildpack-elixir#200

Sorry to revert, but I'm getting a lot of reports from customers that this has broken the build with the following error.

remote: /tmp/build/.platform_tools/elixir/bin/elixir: 230: exec: erl: not found

I'm also not 100% sure if all of the pull request comments were addressed, which is why I didn't merge it before.