### PR TITLE
use MIX_HOME,HEX_HOME when installing mix/hex dependencies

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,10 +25,12 @@ source ${build_pack_path}/lib/elixir_funcs.sh
 source ${build_pack_path}/lib/app_funcs.sh
 source ${build_pack_path}/lib/canonical_version.sh
 
-mkdir $(platform_tools_path)
+mkdir $(build_platform_tools_path)
 
 export_env_vars
 export_mix_env
+export_mix_home
+export_hex_home
 load_config
 check_erlang_version "$erlang_version"
 

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -14,27 +14,17 @@ function restore_app() {
 
 
 function copy_hex() {
-  mkdir -p ${build_path}/.mix/archives
-  mkdir -p ${build_path}/.hex
+  mkdir -p $(runtime_hex_home_path)
 
-
-  # hex is a directory from elixir-1.3.0
-  full_hex_file_path=$(ls -dt ${HOME}/.mix/archives/hex-* | head -n 1)
-
-  # hex file names after elixir-1.1 in the hex-<version>.ez form
-  if [ -z "$full_hex_file_path" ]; then
-    full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-*.ez | head -n 1)
+  # copying hex is only necessary on the old build system.
+  # If the build_hex_home_path is the same as runtime_hex_home_path
+  # (which is specifified by the buildpack consumer in their elixir_buildpack.config),
+  # then we don't need to copy (and doing so will result in an error)
+  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194
+  if [ $(build_hex_home_path) != $(runtime_hex_home_path) ]; then
+    output_section "Copying hex from $(build_hex_home_path)"
+    cp -R $(build_hex_home_path)/* "$(runtime_hex_home_path)/"
   fi
-
-  # For older versions of hex which have no version name in file
-  if [ -z "$full_hex_file_path" ]; then
-    full_hex_file_path=${HOME}/.mix/archives/hex.ez
-  fi
-
-  cp -R ${HOME}/.hex/* ${build_path}/.hex/
-
-  output_section "Copying hex from $full_hex_file_path"
-  cp -R $full_hex_file_path ${build_path}/.mix/archives
 }
 
 function hook_pre_app_dependencies() {
@@ -71,16 +61,17 @@ function hook_post_compile() {
 }
 
 function app_dependencies() {
-  # Unset this var so that if the parent dir is a git repo, it isn't detected
-  # And all git operations are performed on the respective repos
-  local git_dir_value=$GIT_DIR
-  unset GIT_DIR
+  mkdir -p "$(build_mix_home_path)"
 
   cd $build_path
   output_section "Fetching app dependencies with mix"
-  mix deps.get --only $MIX_ENV || exit 1
 
-  export GIT_DIR=$git_dir_value
+  # Unset this var so that if the parent dir is a git repo, it isn't detected
+  # And all git operations are performed on the respective repos
+  env \
+    -u GIT_DIR \
+    mix deps.get --only $MIX_ENV || exit 1
+
   cd - > /dev/null
 }
 
@@ -148,33 +139,62 @@ function pre_compile_hook() {
   cd - > /dev/null
 }
 
+function export_var() {
+  local VAR_NAME=$1
+  local VAR_VALUE=$2
+
+  echo "export ${VAR_NAME}=${VAR_VALUE}"
+}
+
+function export_default_var() {
+  local VAR_NAME=$1
+  local DEFAULT_VALUE=$2
+
+  if [ ! -f "${env_path}/${VAR_NAME}" ]; then
+    export_var "${VAR_NAME}" "${DEFAULT_VALUE}"
+  fi
+}
+
+function echo_profile_env_vars() {
+  local buildpack_bin="$(runtime_platform_tools_path)"
+  buildpack_bin="$(runtime_erlang_path)/bin:${buildpack_bin}"
+  buildpack_bin="$(runtime_elixir_path)/bin:${buildpack_bin}"
+
+
+  export_var "PATH" "${buildpack_bin}:\$PATH"
+  export_default_var "LC_CTYPE" "en_US.utf8"
+
+  # Only write MIX_* to profile if the application did not set MIX_*
+  export_default_var "MIX_ENV" "${MIX_ENV}"
+  export_default_var "MIX_HOME" "$(runtime_mix_home_path)"
+  export_default_var "HEX_HOME" "$(runtime_hex_home_path)"
+}
+
+function echo_export_env_vars() {
+  local buildpack_bin="$(build_platform_tools_path)"
+  buildpack_bin="$(build_erlang_path)/bin:${buildpack_bin}"
+  buildpack_bin="$(build_elixir_path)/bin:${buildpack_bin}"
+
+
+  export_var "PATH" "${buildpack_bin}:\$PATH"
+  export_default_var "LC_CTYPE" "en_US.utf8"
+
+  # Only write MIX_* to profile if the application did not set MIX_*
+  export_default_var "MIX_ENV" "${MIX_ENV}"
+  export_default_var "MIX_HOME" "$(build_mix_home_path)"
+  export_default_var "HEX_HOME" "$(build_hex_home_path)"
+}
+
 function write_profile_d_script() {
   output_section "Creating .profile.d with env vars"
   mkdir -p $build_path/.profile.d
+  local profile_path="${build_path}/.profile.d/elixir_buildpack_paths.sh"
 
-  local export_line="export PATH=\$HOME/.platform_tools:\$HOME/.platform_tools/erlang/bin:\$HOME/.platform_tools/elixir/bin:\$PATH
-                     export LC_CTYPE=en_US.utf8"
-
-  # Only write MIX_ENV to profile if the application did not set MIX_ENV
-  if [ ! -f $env_path/MIX_ENV ]; then
-    export_line="${export_line}
-                 export MIX_ENV=${MIX_ENV}"
-  fi
-
-  echo $export_line >> $build_path/.profile.d/elixir_buildpack_paths.sh
+  echo_profile_env_vars >> $profile_path
 }
 
 function write_export() {
   output_section "Writing export for multi-buildpack support"
 
-  local export_line="export PATH=$(platform_tools_path):$(erlang_path)/bin:$(elixir_path)/bin:$PATH
-                     export LC_CTYPE=en_US.utf8"
-
-  # Only write MIX_ENV to export if the application did not set MIX_ENV
-  if [ ! -f $env_path/MIX_ENV ]; then
-    export_line="${export_line}
-                 export MIX_ENV=${MIX_ENV}"
-  fi
-
-  echo $export_line > $build_pack_path/export
+  echo_export_env_vars >> "${build_pack_path}/export"
 }

--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -26,8 +26,9 @@ function download_elixir() {
 function install_elixir() {
   output_section "Installing Elixir ${elixir_version} $(elixir_changed)"
 
-  mkdir -p $(elixir_path)
-  cd $(elixir_path)
+  mkdir -p $(build_elixir_path)
+
+  cd $(build_elixir_path)
 
   if type "unzip" &> /dev/null; then
     unzip -q $(elixir_cache_path)/$(elixir_download_file)
@@ -37,8 +38,13 @@ function install_elixir() {
 
   cd - > /dev/null
 
-  chmod +x $(elixir_path)/bin/*
-  PATH=$(elixir_path)/bin:${PATH}
+  if [ $(build_elixir_path) != $(runtime_elixir_path) ]; then
+    mkdir -p $(runtime_elixir_path)
+    cp -R $(build_elixir_path)/* $(runtime_elixir_path)
+  fi
+
+  chmod +x $(build_elixir_path)/bin/*
+  PATH=$(build_elixir_path)/bin:${PATH}
 
   export LC_CTYPE=en_US.utf8
 }
@@ -55,13 +61,13 @@ function clean_elixir_downloads() {
 
 function restore_mix() {
   if [ -d $(mix_backup_path) ]; then
-    mkdir -p ${HOME}/.mix
-    cp -pR $(mix_backup_path)/* ${HOME}/.mix
+    mkdir -p $(build_mix_home_path)
+    cp -pR $(mix_backup_path)/* $(build_mix_home_path)
   fi
 
   if [ -d $(hex_backup_path) ]; then
-    mkdir -p ${HOME}/.hex
-    cp -pR $(hex_backup_path)/* ${HOME}/.hex
+    mkdir -p $(build_hex_home_path)
+    cp -pR $(hex_backup_path)/* $(build_hex_home_path)
   fi
 }
 
@@ -71,8 +77,20 @@ function backup_mix() {
 
   mkdir -p $(mix_backup_path) $(hex_backup_path)
 
-  cp -pR ${HOME}/.mix/* $(mix_backup_path)
-  cp -pR ${HOME}/.hex/* $(hex_backup_path)
+  cp -pR $(build_mix_home_path)/* $(mix_backup_path)
+  cp -pR $(build_hex_home_path)/* $(hex_backup_path)
+
+  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194
+  if [ $(build_hex_home_path) != $(runtime_hex_home_path) ]; then
+    mkdir -p $(runtime_hex_home_path)
+    cp -pR $(build_hex_home_path)/* $(runtime_hex_home_path)
+  fi
+
+  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194
+  if [ $(build_mix_home_path) != $(runtime_mix_home_path) ]; then
+    mkdir -p $(runtime_mix_home_path)
+    cp -pR $(build_mix_home_path)/* $(runtime_mix_home_path)
+  fi
 }
 
 function install_hex() {
@@ -89,6 +107,7 @@ function install_rebar() {
 function elixir_changed() {
   if [ $elixir_changed = true ]; then
     echo "(changed)"
+    clean_elixir_version_dependent_cache
   fi
 }
 

--- a/lib/erlang_funcs.sh
+++ b/lib/erlang_funcs.sh
@@ -3,9 +3,9 @@ function erlang_tarball() {
 }
 
 function download_erlang() {
+  mkdir -p $(erlang_cache_path)
   erlang_package_url="$(erlang_builds_url)/$(erlang_tarball)"
 
-  mkdir -p $(erlang_cache_path)
   # If a previous download does not exist, then always re-download
   if [ ! -f $(erlang_cache_path)/$(erlang_tarball) ]; then
     clean_erlang_downloads
@@ -28,17 +28,29 @@ function clean_erlang_downloads() {
 function install_erlang() {
   output_section "Installing Erlang ${erlang_version} $(erlang_changed)"
 
-  rm -rf $(erlang_build_path)
-  mkdir -p $(erlang_build_path)
-  tar zxf $(erlang_cache_path)/$(erlang_tarball) -C $(erlang_build_path) --strip-components=1
+  local tmp_path=$(mktemp -d)
+
+  tar zxf $(erlang_cache_path)/$(erlang_tarball) -C "${tmp_path}" --strip-components=1
 
   rm -rf $(runtime_erlang_path)
   mkdir -p $(runtime_platform_tools_path)
-  ln -s $(erlang_build_path) $(runtime_erlang_path)
-  $(erlang_build_path)/Install -minimal $(runtime_erlang_path)
+  ln -s ${tmp_path} $(runtime_erlang_path)
+  ${tmp_path}/Install -minimal $(runtime_erlang_path)
 
-  cp -R $(erlang_build_path) $(erlang_path)
-  PATH=$(erlang_path)/bin:$PATH
+  # remove symlink so we can copy into the BUILD_DIR without symlinks
+  rm $(runtime_erlang_path)
+  mkdir -p $(runtime_erlang_path)
+  cp -R ${tmp_path}/* $(runtime_erlang_path)
+
+  # only copy if using old build system;
+  # newer versions of the build system run builds with BUILD_PATH=/app
+  # https://github.com/HashNuke/heroku-buildpack-elixir/issues/194#issuecomment-800425532
+  if [ $(build_erlang_path) != $(runtime_erlang_path) ]; then
+    mkdir -p $(build_erlang_path)
+    cp -R $(runtime_erlang_path)/* $(build_erlang_path)
+  fi
+
+  PATH=$(runtime_erlang_path)/bin:$PATH
 }
 
 function erlang_changed() {

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -101,6 +101,26 @@ function export_mix_env() {
   output_line "* MIX_ENV=${MIX_ENV}"
 }
 
+function export_mix_home() {
+  if [ -z "$MIX_HOME" ]; then
+    if [ -d $env_path ] && [ -f $env_path/MIX_HOME ]; then
+      export MIX_HOME=$(cat $env_path/MIX_HOME)
+    else
+      export MIX_HOME=$(build_mix_home_path)
+    fi
+  fi
+}
+
+function export_hex_home() {
+  if [ -z "$HEX_HOME" ]; then
+    if [ -d $env_path ] && [ -f $env_path/HEX_HOME ]; then
+      export HEX_HOME=$(cat $env_path/HEX_HOME)
+    else
+      export HEX_HOME=$(build_hex_home_path)
+    fi
+  fi
+}
+
 function check_stack() {
   if [ "${STACK}" = "cedar" ]; then
     echo "ERROR: cedar stack is not supported, upgrade to cedar-14"
@@ -120,13 +140,19 @@ function check_stack() {
 # function
 function clean_old_cache_files() {
   rm -rf \
-    $(erlang_build_path) \
+    $(build_erlang_path) \
     ${cache_path}/deps_backup \
     ${cache_path}/build_backup \
     ${cache_path}/.mix \
     ${cache_path}/.hex
   rm -rf ${cache_path}/OTP-*.zip
   rm -rf ${cache_path}/elixir*.zip
+}
+
+function clean_elixir_version_dependent_cache() {
+  rm -rf \
+    $(hex_backup_path) \
+    $(mix_backup_path)
 }
 
 function clean_cache() {

--- a/lib/path_funcs.sh
+++ b/lib/path_funcs.sh
@@ -1,41 +1,41 @@
-function platform_tools_path() {
+function build_platform_tools_path() {
   echo "${build_path}/.platform_tools"
-}
-
-function erlang_path() {
-  echo "$(platform_tools_path)/erlang"
 }
 
 function runtime_platform_tools_path() {
   echo "${runtime_path}/.platform_tools"
 }
 
+function build_erlang_path() {
+  echo "$(build_platform_tools_path)/erlang"
+}
+
 function runtime_erlang_path() {
   echo "$(runtime_platform_tools_path)/erlang"
 }
 
-function elixir_path() {
-  echo "$(platform_tools_path)/elixir"
+function build_elixir_path() {
+  echo "$(build_platform_tools_path)/elixir"
 }
 
-function generate_tmp_erlang_build_dir() {
-  # Do not call this in a subshell e.g. $(generate_tmp_erlang_build_dir)
-  tmp_erlang_build_dir="$(mktemp -d)"
+function runtime_elixir_path() {
+  echo "$(runtime_platform_tools_path)/elixir"
 }
 
-# We just go head and call it here before erlang_build_path is even defined so we should be good
-generate_tmp_erlang_build_dir
+function build_hex_home_path() {
+  echo "${build_path}/.hex"
+}
 
-function erlang_build_path() {
-  if [ -z "$tmp_erlang_build_dir" ]; then
-    # We have to generate this tmp folder outside this function because this function is often called
-    # in a subshell. If we generate the tmp folder inside the subshell, we can not remember the folder
-    # name in the parent shell and subsequent calls to this function will return a different folder.
-    # See https://stackoverflow.com/questions/23564995/how-to-modify-a-global-variable-within-a-function-in-bash
-    output_warning "You must call generate_tmp_erlang_build_dir before calling erlang_build_path"
-    exit 1
-  fi
-  echo "${tmp_erlang_build_dir}/erlang"
+function runtime_hex_home_path() {
+  echo "${runtime_path}/.hex"
+}
+
+function build_mix_home_path() {
+  echo "${build_path}/.mix"
+}
+
+function runtime_mix_home_path() {
+  echo "${runtime_path}/.mix"
 }
 
 function stack_based_cache_path() {


### PR DESCRIPTION
tl;dr:

- Instead of relying on Mix's default behavior of installing to `$HOME/.mix`, the buildpack sets `$MIX_HOME` to a directory controlled by the buildpack when running `mix`
- Instead of relying on Hex's default behavior of installing to `$HOME/.hex`, the buildpack sets `$HEX_HOME` to a directory controlled by the buildpack when running `hex`
- The buildpack now exports `HEX_HOME` and `MIX_HOME` if they are not set as configuration variables.

By using `MIX_HOME` and `HEX_HOME`, we can consolidate some logic for transferring mix/hex files in and out of the cache and app build directory.

This should allow the buildpack to work in the new build system and the old build system since this buildpack no longer relies on what the value of `HOME` is at either build time or runtime.

fixes #194

https://github.com/HashNuke/heroku-buildpack-elixir/issues/194

# The Longer Explanation

This strategy was taken from the [heroku-buildpack-ruby buildpack][1], which sets [GEM_HOME and GEM_PATH environment variables][2] as well as the [`BUNDLE_PATH` environment variable][3] to a path in the `BUILD_DIR` argument when running the `bundle install` command.

Although the Elixir programming langauge and buildpack doesn't use Bundler/Rubygems, it has similar patterns for setting the installation directory and archive paths for Mix and Hex.

`MIX_HOME` has been supported since `v0.7.0` of Elixir ([support for `MIX_HOME` added ~9 years ago][4]).

Note: There is a `MIX_ARCHIVES` env variable that Mix can use, but [MIX_ARCHIVES support was added in version 0.14.7][5]. I'm not sure if anyone is still using this Elixir version (they should upgrade as the OTP that 0.14.7 supports is very outdated and doesn't receive security updates). If `MIX_ARCHIVES` is not present, then [Mix will put archives in `$MIX_HOME/archives`][6]. In order to keep compatibility as close as possible, this commit continues using the old strategy of backing up everything in `MIX_HOME`, rather than what's in `MIX_ARCHIVES` alone.

[`HEX_HOME` support was added in Hex v0.3.3][7]. This was the commit that made Hex put stuff in `$HEX_HOME` directory, meaning that support for `HEX_HOME` has existed for a long time and we should be able to rely on Hex using the `HEX_HOME` directory. The old strategy used by the Elixir buildpack always backed up the default `HEX_HOME` value (`$HOME/.hex`).

[1]: https://github.com/heroku/heroku-buildpack-ruby
[2]: https://github.com/heroku/heroku-buildpack-ruby/blob/52e02d56370c1e05434bc550a06f1bcde5849644/lib/language_pack/ruby.rb#L324-L325
[3]: https://github.com/heroku/heroku-buildpack-ruby/blob/52e02d56370c1e05434bc550a06f1bcde5849644/lib/language_pack/ruby.rb#L349
[4]: https://github.com/elixir-lang/elixir/commit/e518c5263e66d6554c7229d170a94b8afac25f70#diff-ff4ab450307d771fedb0471df59d9bd71f4f90559375d57f8015fda8ba4cf301R21
[5]: https://github.com/elixir-lang/elixir/commit/02a415facdfc86373eebaf507b83061b291fd6d2#diff-75787cbe3255513265f665bb859b99a624db2b56bec01e48455cd63577ad8cadR16
[6]: https://github.com/elixir-lang/elixir/blob/c57d08a32f1308769a2fbaf7a2fe385ab2fb5d22/lib/mix/lib/mix.ex#L463
[7]: https://github.com/hexpm/hex/commit/5dd8ae020dc4c31bc662e490c79221423fc5d9f6
