### PR TITLE
Add support for Heroku Stack-22.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * Erlang - Prebuilt packages (17.5, 17.4, etc)
   * The full list of prebuilt packages can be found here: 
     * gigalixir-20 or heroku-20 stacks: https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt
+    * heroku-22 stacks: https://repo.hex.pm/builds/otp/ubuntu-22.04/builds.txt
     * All other stacks: https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
 * Elixir - Prebuilt releases (1.0.4, 1.0.3, etc) or prebuilt branches (master, v1.7, etc)
   * The full list of releases can be found here: https://github.com/elixir-lang/elixir/releases

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 
 erlang_builds_url() {
-  if [ "$STACK" = "heroku-20" ]; then
-    erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
-  else
-    erlang_builds_url="https://s3.amazonaws.com/heroku-buildpack-elixir/erlang/cedar-14"
-  fi
+  case "${STACK}" in
+    "heroku-20")
+      erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
+      ;;
+    "heroku-22")
+      erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-22.04"
+      ;;
+    *)
+      erlang_builds_url="https://s3.amazonaws.com/heroku-buildpack-elixir/erlang/cedar-14"
+      ;;
+  esac
   echo $erlang_builds_url
 }
 
@@ -15,13 +21,20 @@ fetch_elixir_versions() {
 }
 
 fetch_erlang_versions() {
-  if [ "$STACK" = "heroku-20" ]; then
-    url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
-    curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
-  else
-    url="https://raw.githubusercontent.com/HashNuke/heroku-buildpack-elixir-otp-builds/master/otp-versions"
-    curl -s "$url"
-  fi
+  case "${STACK}" in
+    "heroku-20")
+      url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
+      curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
+      ;;
+    "heroku-22")
+      url="https://repo.hex.pm/builds/otp/ubuntu-22.04/builds.txt"
+      curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
+      ;;
+    *)
+      url="https://raw.githubusercontent.com/HashNuke/heroku-buildpack-elixir-otp-builds/master/otp-versions"
+      curl -s "$url"
+      ;;
+  esac
 }
 
 exact_erlang_version_available() {


### PR DESCRIPTION
Fixes #210 

Heroku recently released the new stack-22 based on Ubuntu 22.04. We just need to add the OTP build urls for Ubuntu 22.04 and we're good to go. I've tested the changes with my fork of this repo and successfully deployed a stack-22 app.

Merging this would be appreciated.

Best regards,
Kai

