### PR TITLE
Add support for Scalingo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 * Erlang - Prebuilt packages (17.5, 17.4, etc)
   * The full list of prebuilt packages can be found here: 
-    * gigalixir-20 or heroku-20 stacks: https://builds.hex.pm/builds/otp/ubuntu-20.04/builds.txt
+    * gigalixir-20, heroku-20 or scalingo-20 stacks: https://builds.hex.pm/builds/otp/ubuntu-20.04/builds.txt
     * heroku-22 stacks: https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
     * All other stacks: https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
 * Elixir - Prebuilt releases (1.0.4, 1.0.3, etc) or prebuilt branches (master, v1.7, etc)

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -8,6 +8,9 @@ erlang_builds_url() {
     "heroku-22")
       erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-22.04"
       ;;
+    "scalingo-20")
+      erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
+      ;;
     *)
       erlang_builds_url="https://s3.amazonaws.com/heroku-buildpack-elixir/erlang/cedar-14"
       ;;
@@ -24,6 +27,10 @@ fetch_erlang_versions() {
   case "${STACK}" in
     "heroku-20")
       url="https://builds.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
+      curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
+      ;;
+    "scalingo-20")
+      url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
       ;;
     "heroku-22")

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -9,7 +9,10 @@ erlang_builds_url() {
       erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-22.04"
       ;;
     "scalingo-20")
-      erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
+      erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-20.04"
+      ;;
+    "scalingo-22")
+      erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-22.04"
       ;;
     *)
       erlang_builds_url="https://s3.amazonaws.com/heroku-buildpack-elixir/erlang/cedar-14"

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -33,7 +33,11 @@ fetch_erlang_versions() {
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
       ;;
     "scalingo-20")
-      url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
+      url="https://builds.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
+      curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
+      ;;
+    "scalingo-22")
+      url="https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt"
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
       ;;
     "heroku-22")


### PR DESCRIPTION
Hi there,

thank you so much for this build pack. I've been using it for a while with Scalingo. Scalingo has added [Scalingo-20](https://doc.scalingo.com/platform/internals/stacks/scalingo-20-stack) as their new default stack a while ago, which is no longer compatible with older prebuilt packages.

I've added support for Scalingo-20, it works just fine with the packages for gigalixir-20 and heroku-20. 

Would you be interested in adding this? Otherwise I can just continue using my fork.

I've added a blog post on how to [deploy phoenix to scalingo here](https://b310.de/blog/scalingo-phoenix-1-6.html).
